### PR TITLE
[kube-prometheus-stack] - Ensure thanos-ruler related resource names are within allowed 63 character length limit

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -22,7 +22,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 41.5.1
+version: 41.5.2
 appVersion: 0.60.1
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus

--- a/charts/kube-prometheus-stack/templates/_helpers.tpl
+++ b/charts/kube-prometheus-stack/templates/_helpers.tpl
@@ -57,6 +57,12 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{- printf "%s-thanos-ruler" (include "kube-prometheus-stack.fullname" .) -}}
 {{- end }}
 
+{{/* Shortened name suffixed with thanos-ruler */}}
+{{- define "kube-prometheus-stack.thanosRuler.name" -}}
+{{- default (printf "%s-thanos-ruler" (include "kube-prometheus-stack.name" .)) .Values.thanosRuler.name -}}
+{{- end }}
+
+
 {{/* Create chart name and version as used by the chart label. */}}
 {{- define "kube-prometheus-stack.chartref" -}}
 {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}
@@ -106,7 +112,7 @@ heritage: {{ $.Release.Service | quote }}
 {{/* Create the name of thanosRuler service account to use */}}
 {{- define "kube-prometheus-stack.thanosRuler.serviceAccountName" -}}
 {{- if .Values.thanosRuler.serviceAccount.create -}}
-    {{ default (include "kube-prometheus-stack.thanosRuler.fullname" .) .Values.thanosRuler.serviceAccount.name }}
+    {{ default (include "kube-prometheus-stack.thanosRuler.name" .) .Values.thanosRuler.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.thanosRuler.serviceAccount.name }}
 {{- end -}}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/extrasecret.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/extrasecret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thanosRuler.extraSecret.data -}}
-{{- $secretName := printf "thanos-ruler-%s-extra" (include "kube-prometheus-stack.fullname" . ) -}}
+{{- $secretName := printf "%s-extra" (include "kube-prometheus-stack.thanosRuler.name" . ) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +10,7 @@ metadata:
 {{ toYaml .Values.thanosRuler.extraSecret.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
     app.kubernetes.io/component: thanos-ruler
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ingress.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.thanosRuler.enabled .Values.thanosRuler.ingress.enabled }}
 {{- $pathType := .Values.thanosRuler.ingress.pathType | default "ImplementationSpecific" }}
-{{- $serviceName := printf "%s-%s" (include "kube-prometheus-stack.fullname" .) "thanos-ruler" }}
+{{- $serviceName := include "kube-prometheus-stack.thanosRuler.name" . }}
 {{- $servicePort := .Values.thanosRuler.service.port -}}
 {{- $routePrefix := list .Values.thanosRuler.thanosRulerSpec.routePrefix }}
 {{- $paths := .Values.thanosRuler.ingress.paths | default $routePrefix -}}
@@ -16,7 +16,7 @@ metadata:
 {{ toYaml .Values.thanosRuler.ingress.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{- if .Values.thanosRuler.ingress.labels }}
 {{ toYaml .Values.thanosRuler.ingress.labels | indent 4 }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/podDisruptionBudget.yaml
@@ -2,10 +2,10 @@
 apiVersion: {{ include "kube-prometheus-stack.pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   {{- if .Values.thanosRuler.podDisruptionBudget.minAvailable }}
@@ -17,5 +17,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-ruler
-      thanos-ruler: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+      thanos-ruler: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/ruler.yaml
@@ -2,11 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ThanosRuler
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+    app: {{ include "kube-prometheus-stack.thanosRuler.name" . }}
+{{- include "kube-prometheus-stack.labels" . | indent 4 -}}
 {{- if .Values.thanosRuler.annotations }}
   annotations:
 {{ toYaml .Values.thanosRuler.annotations | indent 4 }}
@@ -34,7 +34,7 @@ spec:
 {{- else if and .Values.thanosRuler.ingress.enabled .Values.thanosRuler.ingress.hosts }}
   externalPrefix: "http://{{ tpl (index .Values.thanosRuler.ingress.hosts 0) . }}{{ .Values.thanosRuler.thanosRulerSpec.routePrefix }}"
 {{- else }}
-  externalPrefix: http://{{ template "kube-prometheus-stack.fullname" . }}-thanosRuler.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.thanosRuler.service.port }}
+  externalPrefix: http://{{ template "kube-prometheus-stack.thanosRuler.name" . }}.{{ template "kube-prometheus-stack.namespace" . }}:{{ .Values.thanosRuler.service.port }}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.nodeSelector }}
   nodeSelector:
@@ -125,7 +125,7 @@ spec:
         labelSelector:
           matchExpressions:
             - {key: app.kubernetes.io/name, operator: In, values: [thanos-ruler]}
-            - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler]}
+            - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.thanosRuler.name" . }}]}
 {{- else if eq .Values.thanosRuler.thanosRulerSpec.podAntiAffinity "soft" }}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -135,7 +135,7 @@ spec:
           labelSelector:
             matchExpressions:
               - {key: app.kubernetes.io/name, operator: In, values: [thanos-ruler]}
-              - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler]}
+              - {key: thanos-ruler, operator: In, values: [{{ template "kube-prometheus-stack.thanosRuler.name" . }}]}
 {{- end }}
 {{- if .Values.thanosRuler.thanosRulerSpec.tolerations }}
   tolerations:

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/service.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
     self-monitor: {{ .Values.thanosRuler.serviceMonitor.selfMonitor | quote }}
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- include "kube-prometheus-stack.labels" . | indent 4 -}}
 {{- if .Values.thanosRuler.service.labels }}
 {{ toYaml .Values.thanosRuler.service.labels | indent 4 }}
 {{- end }}
@@ -48,6 +48,6 @@ spec:
 {{- end }}
   selector:
     app.kubernetes.io/name: thanos-ruler
-    thanos-ruler: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+    thanos-ruler: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
   type: "{{ .Values.thanosRuler.service.type }}"
 {{- end }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/serviceaccount.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/serviceaccount.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ template "kube-prometheus-stack.thanosRuler.serviceAccountName" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
-    app.kubernetes.io/name: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
+    app.kubernetes.io/name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
     app.kubernetes.io/component: thanos-ruler
-{{ include "kube-prometheus-stack.labels" . | indent 4 }}
+{{- include "kube-prometheus-stack.labels" . | indent 4 -}}
 {{- if .Values.thanosRuler.serviceAccount.annotations }}
   annotations:
 {{ toYaml .Values.thanosRuler.serviceAccount.annotations | indent 4 }}

--- a/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
+++ b/charts/kube-prometheus-stack/templates/thanos-ruler/servicemonitor.yaml
@@ -2,15 +2,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ template "kube-prometheus-stack.fullname" . }}-thanos-ruler
+  name: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
   namespace: {{ template "kube-prometheus-stack.namespace" . }}
   labels:
-    app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+    app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
 {{ include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "kube-prometheus-stack.name" . }}-thanos-ruler
+      app: {{ template "kube-prometheus-stack.thanosRuler.name" . }}
       release: {{ $.Release.Name | quote }}
       self-monitor: {{ .Values.thanosRuler.serviceMonitor.selfMonitor | quote }}
   namespaceSelector:


### PR DESCRIPTION
Updated thanos ruler name to use the shortened helm chart name + thanos-rule suffix to ensure that the thanos ruler name is always under the required 63 characters for thanos-ruler related resources/.

Added support for overriding the value for the thanos ruler directly from the values file for the thanos ruler name (if set at .Values.thanosRuler.name) otherwise default back to shorted helm chart name + thanos-ruler i.e.. kube-prometheus-stack-thanos-ruler.

<!--
Thank you for contributing to prometheus-community/helm-charts.
Before you submit this pull request we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in prometheus-community/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your pull request merged quicker.

When updates to your pull request are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The pull request will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once the pull request is opened, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
If you are contributing to this repository for the first time, a maintainer will need to approve those checks to run.
They are automatically requested as reviewers and will approve the workflows or ask you for changes once they get to it.

We would like these checks to pass before we even continue reviewing your changes.
-->

<!-- markdownlint-disable-next-line first-line-heading -->
#### What this PR does / why we need it

When deploying the Thanos Ruler with default values, the generated name for volumes attached to pods is too long, blocking it (more than 63 chars).

It creates a volume named thanos-ruler-<release_name>-kube-prometheus-stack-thanos-ruler-rulefiles-0, and then you get this error:

$ kubectl get events
`29s         Warning   FailedCreate       statefulset/thanos-ruler-prom-kube-prometheus-stack-thanos-ruler   create Pod thanos-ruler-prom-kube-prometheus-stack-thanos-ruler-0 in StatefulSet thanos-ruler-prom-kube-prometheus-stack-thanos-ruler failed error: Pod "thanos-ruler-prom-kube-prometheus-stack-thanos-ruler-0" is invalid: [spec.volumes[0].name: Invalid value: "thanos-ruler-prom-kube-prometheus-stack-thanos-ruler-rulefiles-0": must be no more than 63 characters, spec.containers[0].volumeMounts[1].name: Not found: "thanos-ruler-prom-kube-prometheus-stack-thanos-ruler-rulefiles-0", spec.containers[1].volumeMounts[0].name: Not found: "thanos-ruler-prom-kube-prometheus-stack-thanos-ruler-rulefiles-0"]`


#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- fixes #2408

#### Special notes for your reviewer

Tested locally and applied successfully against our dev k8s cluster.

#### Checklist

<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/prometheus-community/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[prometheus-couchdb-exporter]`)
